### PR TITLE
fix(quickstart): smoother Colab UX (GPU default, conditional install, batch breakdown)

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -2,91 +2,124 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5881277c",
+   "id": "c6bfb327",
    "metadata": {},
    "source": [
     "# scmidas quickstart\n",
     "\n",
     "Five lines from `pip install scmidas` to a UMAP of mosaic-integrated single-cell multi-omic data.\n",
     "\n",
-    "This notebook trains MIDAS on a **toy 1600-cell PBMC mosaic dataset** (RNA + ADT, 4 batches with paired and unpaired modality combinations) bundled inside the package. On a free Colab T4 GPU end-to-end takes about 2 minutes; on a local mid-range GPU about 1 minute.\n",
+    "**On a free Colab T4 GPU** the entire notebook (install + train + UMAP) runs in roughly 2 minutes. **On a local mid-range GPU** the training step alone is ~1 minute.\n",
     "\n",
-    "> ⚠️ **The default `scmidas.integrate(...)` hyperparameters are tuned for this toy dataset**, not for your own data. For a real analysis, see [demo2 / demo3](https://scmidas.readthedocs.io/en/latest/) and tune `max_epochs`, `batch_size` accordingly."
+    "This notebook trains MIDAS on a 1600-cell PBMC RNA+ADT mosaic dataset bundled inside the package — no extra downloads, no config files, no data prep.\n",
+    "\n",
+    "> ⚠️ **The defaults in `scmidas.integrate()` are tuned for this toy dataset.** They are *not* general-purpose. For a real analysis, override `max_epochs` (1000-2000) and `batch_size` (256). See [demo2 / demo3](https://scmidas.readthedocs.io/en/latest/) for full pipelines."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8792bc14",
+   "id": "884fe652",
    "metadata": {},
    "source": [
-    "## 1. Install (Colab only)"
+    "## 1. Install\n",
+    "\n",
+    "Skipped if `scmidas` is already importable (e.g. local Jupyter). On Colab the `pip install` may print a benign \"dependency resolver\" warning about Colab's pre-pinned `pandas` — this is harmless and doesn't affect the demo."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c46a8c24",
+   "id": "2652e5a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T05:44:21.109192Z",
-     "iopub.status.busy": "2026-05-03T05:44:21.108326Z",
-     "iopub.status.idle": "2026-05-03T05:44:21.110400Z",
-     "shell.execute_reply": "2026-05-03T05:44:21.109789Z"
+     "iopub.execute_input": "2026-05-03T07:17:54.442360Z",
+     "iopub.status.busy": "2026-05-03T07:17:54.441760Z",
+     "iopub.status.idle": "2026-05-03T07:17:54.445939Z",
+     "shell.execute_reply": "2026-05-03T07:17:54.446382Z"
     }
    },
    "outputs": [],
    "source": [
-    "# Uncomment the next line on Colab; skip if scmidas is already installed.\n",
-    "# !pip install scmidas"
+    "import importlib.util\n",
+    "if importlib.util.find_spec('scmidas') is None:\n",
+    "    !pip install --quiet scmidas"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "023f43b7",
+   "id": "5d181140",
    "metadata": {},
    "source": [
-    "## 2. Load the bundled quickstart dataset\n",
+    "## 2. Confirm a GPU is available\n",
     "\n",
-    "A 1600-cell PBMC mosaic MuData (RNA + ADT). 4 batches with the typical mosaic structure: one RNA-only, one ADT-only, two with both modalities."
+    "If you see a warning here, the notebook is running on CPU and training will take ~5-10 minutes instead of ~1 minute. **To enable a GPU on Colab**: `Runtime → Change runtime type → Hardware accelerator → T4 GPU`, then `Runtime → Restart and run all`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ee9385e5",
+   "id": "ba29b01f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T05:44:21.116404Z",
-     "iopub.status.busy": "2026-05-03T05:44:21.115804Z",
-     "iopub.status.idle": "2026-05-03T05:44:25.934178Z",
-     "shell.execute_reply": "2026-05-03T05:44:25.935356Z"
+     "iopub.execute_input": "2026-05-03T07:17:54.450879Z",
+     "iopub.status.busy": "2026-05-03T07:17:54.450252Z",
+     "iopub.status.idle": "2026-05-03T07:17:56.003269Z",
+     "shell.execute_reply": "2026-05-03T07:17:56.004440Z"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<pre>MuData object with n_obs × n_vars = 1600 × 724\n",
-       "  obs:\t&#x27;batch&#x27;, &#x27;celltype&#x27;\n",
-       "  2 modalities\n",
-       "    rna:\t1200 × 500\n",
-       "      obs:\t&#x27;batch&#x27;, &#x27;celltype&#x27;\n",
-       "    adt:\t1200 × 224\n",
-       "      obs:\t&#x27;batch&#x27;, &#x27;celltype&#x27;</pre>"
-      ],
-      "text/plain": [
-       "MuData object with n_obs × n_vars = 1600 × 724\n",
-       "  obs:\t'batch', 'celltype'\n",
-       "  2 modalities\n",
-       "    rna:\t1200 × 500\n",
-       "      obs:\t'batch', 'celltype'\n",
-       "    adt:\t1200 × 224\n",
-       "      obs:\t'batch', 'celltype'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ GPU detected: Tesla V100S-PCIE-32GB\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f'✓ GPU detected: {torch.cuda.get_device_name(0)}')\n",
+    "else:\n",
+    "    print('⚠️  No GPU detected. Training will fall back to CPU (~5-10 min).')\n",
+    "    print('   Colab: Runtime → Change runtime type → T4 GPU, then Run all.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12d309f9",
+   "metadata": {},
+   "source": [
+    "## 3. Load and inspect the bundled quickstart dataset\n",
+    "\n",
+    "The bundled MuData has 4 batches arranged in the **classic mosaic structure** that MIDAS is built to integrate: one RNA-only batch, one ADT-only batch, and two batches with both modalities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f7a8798e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-03T07:17:56.011366Z",
+     "iopub.status.busy": "2026-05-03T07:17:56.010732Z",
+     "iopub.status.idle": "2026-05-03T07:17:59.017212Z",
+     "shell.execute_reply": "2026-05-03T07:17:59.018372Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-batch breakdown:\n",
+      "  p1_0:  400 cells   modalities: RNA    \n",
+      "  p2_0:  400 cells   modalities: ADT    \n",
+      "  p3_0:  400 cells   modalities: RNA+ADT\n",
+      "  p4_0:  400 cells   modalities: RNA+ADT\n",
+      "\n",
+      "Total: 1600 cells across 4 batches  |  RNA features: 500  |  ADT features: 224\n"
+     ]
     }
    ],
    "source": [
@@ -98,29 +131,37 @@
     "import scmidas\n",
     "\n",
     "mdata = scmidas.datasets.quickstart()\n",
-    "mdata"
+    "\n",
+    "print('Per-batch breakdown:')\n",
+    "for b in sorted(set(mdata['rna'].obs['batch']) | set(mdata['adt'].obs['batch'])):\n",
+    "    n_rna = int((mdata['rna'].obs['batch'] == b).sum())\n",
+    "    n_adt = int((mdata['adt'].obs['batch'] == b).sum())\n",
+    "    mods = ('RNA' if n_rna else '') + ('+' if n_rna and n_adt else '') + ('ADT' if n_adt else '')\n",
+    "    n_cells = max(n_rna, n_adt)\n",
+    "    print(f'  {b}: {n_cells:>4} cells   modalities: {mods:<7}')\n",
+    "print(f'\\nTotal: {mdata.n_obs} cells across 4 batches  |  RNA features: {mdata[\"rna\"].n_vars}  |  ADT features: {mdata[\"adt\"].n_vars}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "602dc63b",
+   "id": "3407bd94",
    "metadata": {},
    "source": [
-    "## 3. Train\n",
+    "## 4. Train\n",
     "\n",
-    "One call. `scmidas.integrate(...)` infers feature dimensions from the MuData and uses defaults that produce a clean UMAP for this toy dataset in about a minute."
+    "One call. `scmidas.integrate(...)` infers feature dimensions from the MuData and uses defaults that produce a clean UMAP for this toy dataset in about a minute. (The full `MIDAS` class is still available for users who want explicit control.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "e91fadfd",
+   "execution_count": 4,
+   "id": "f7c86538",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T05:44:25.940862Z",
-     "iopub.status.busy": "2026-05-03T05:44:25.940266Z",
-     "iopub.status.idle": "2026-05-03T05:45:29.365469Z",
-     "shell.execute_reply": "2026-05-03T05:45:29.364139Z"
+     "iopub.execute_input": "2026-05-03T07:17:59.023328Z",
+     "iopub.status.busy": "2026-05-03T07:17:59.022581Z",
+     "iopub.status.idle": "2026-05-03T07:19:00.766054Z",
+     "shell.execute_reply": "2026-05-03T07:19:00.767379Z"
     }
    },
    "outputs": [
@@ -178,7 +219,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30186375b1a0421e92b5cf6e4c5dfda4",
+       "model_id": "7118de400bb1442eafa5752cc6c5bbcb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -195,7 +236,7 @@
      "text": [
       "INFO: `Trainer.fit` stopped: `max_epochs=65` reached.\n",
       "INFO:lightning.pytorch.utilities.rank_zero:`Trainer.fit` stopped: `max_epochs=65` reached.\n",
-      "INFO:scmidas.model:Checkpoint successfully saved to \"./saved_models/scmidas/model_epoch65_20260503-054529.pt\".\n"
+      "INFO:scmidas.model:Checkpoint successfully saved to \"./saved_models/scmidas/model_epoch65_20260503-071900.pt\".\n"
      ]
     }
    ],
@@ -205,22 +246,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2550404a",
+   "id": "ca3dc944",
    "metadata": {},
    "source": [
-    "## 4. Compute latent embeddings"
+    "## 5. Compute joint latent embeddings\n",
+    "\n",
+    "Stitch the per-batch latent blocks into one (cells × 32) matrix aligned with the MuData."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "90864802",
+   "execution_count": 5,
+   "id": "ab5b338c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T05:45:29.373813Z",
-     "iopub.status.busy": "2026-05-03T05:45:29.373168Z",
-     "iopub.status.idle": "2026-05-03T05:45:31.692584Z",
-     "shell.execute_reply": "2026-05-03T05:45:31.693556Z"
+     "iopub.execute_input": "2026-05-03T07:19:00.775726Z",
+     "iopub.status.busy": "2026-05-03T07:19:00.774939Z",
+     "iopub.status.idle": "2026-05-03T07:19:03.418845Z",
+     "shell.execute_reply": "2026-05-03T07:19:03.419798Z"
     }
    },
    "outputs": [
@@ -230,13 +273,13 @@
      "text": [
       "INFO:scmidas.model:Predicting using device: cuda\n",
       "INFO:scmidas.model:Processing batch p1_0: ['rna']\n",
-      "predict:p1_0: 100%|██████████| 4/4 [00:00<00:00,  7.04it/s]\n",
+      "predict:p1_0: 100%|██████████| 4/4 [00:00<00:00,  6.48it/s]\n",
       "INFO:scmidas.model:Processing batch p2_0: ['adt']\n",
-      "predict:p2_0: 100%|██████████| 4/4 [00:00<00:00,  6.92it/s]\n",
+      "predict:p2_0: 100%|██████████| 4/4 [00:00<00:00,  6.68it/s]\n",
       "INFO:scmidas.model:Processing batch p3_0: ['rna', 'adt']\n",
-      "predict:p3_0: 100%|██████████| 4/4 [00:00<00:00,  7.30it/s]\n",
+      "predict:p3_0: 100%|██████████| 4/4 [00:00<00:00,  5.18it/s]\n",
       "INFO:scmidas.model:Processing batch p4_0: ['rna', 'adt']\n",
-      "predict:p4_0: 100%|██████████| 4/4 [00:00<00:00,  7.04it/s]"
+      "predict:p4_0: 100%|██████████| 4/4 [00:00<00:00,  6.58it/s]"
      ]
     },
     {
@@ -259,7 +302,6 @@
     "\n",
     "out = model.predict(joint_latent=True)\n",
     "\n",
-    "# stitch per-batch z_c blocks into one (cells × 32) matrix aligned with mdata\n",
     "z_c_blocks, all_ids = [], []\n",
     "for b in ['p1_0', 'p2_0', 'p3_0', 'p4_0']:\n",
     "    z_c_blocks.append(out[b]['z_c']['joint'])\n",
@@ -270,29 +312,29 @@
     "    all_ids.extend(rna_ids + [c for c in adt_ids if c not in set(rna_ids)])\n",
     "z_c = np.vstack(z_c_blocks)\n",
     "\n",
-    "print('latent shape:', z_c.shape)"
+    "print(f'latent shape: {z_c.shape}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "398454cf",
+   "id": "df5c3594",
    "metadata": {},
    "source": [
-    "## 5. UMAP\n",
+    "## 6. UMAP\n",
     "\n",
-    "Color by cell type (left) and source batch (right). MIDAS should produce **lineage-separated clusters** that **mix freely across batches** — the central promise of mosaic integration."
+    "Color by cell type (left) and source batch (right). MIDAS should produce **lineage-separated clusters** (Mono / CD4 T / CD8 T / NK / B / DC) that **mix freely across batches** — the central promise of mosaic integration."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "02880ec2",
+   "execution_count": 6,
+   "id": "c82e6023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T05:45:31.748236Z",
-     "iopub.status.busy": "2026-05-03T05:45:31.733683Z",
-     "iopub.status.idle": "2026-05-03T05:45:39.671502Z",
-     "shell.execute_reply": "2026-05-03T05:45:39.672634Z"
+     "iopub.execute_input": "2026-05-03T07:19:03.476071Z",
+     "iopub.status.busy": "2026-05-03T07:19:03.466191Z",
+     "iopub.status.idle": "2026-05-03T07:19:12.361318Z",
+     "shell.execute_reply": "2026-05-03T07:19:12.362617Z"
     }
    },
    "outputs": [
@@ -345,17 +387,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be94ec90",
+   "id": "0e2f9dc1",
    "metadata": {},
    "source": [
     "## Next steps\n",
     "\n",
-    "- See `docs/source/tutorials/basics/` for the full demos (with real-sized data, multi-GPU training, prediction tasks like imputation, batch correction, modality translation).\n",
+    "- See `docs/source/tutorials/basics/` for the full demos (real-sized data, multi-GPU training, prediction tasks like imputation, batch correction, modality translation).\n",
     "- For your own MuData: `scmidas.integrate(your_mdata, max_epochs=2000, batch_size=256)` (paper-default hyperparameters)."
    ]
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -376,31 +423,25 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "30186375b1a0421e92b5cf6e4c5dfda4": {
+     "1a800a568376411ea0d807398580bb58": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
+      "model_name": "HTMLStyleModel",
       "state": {
-       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
+       "_model_name": "HTMLStyleModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
+       "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_dd59645be4d9462ea87eeb3280ee9463",
-        "IPY_MODEL_c04fd7c0d62f4db1ac61bce7e3fc8987",
-        "IPY_MODEL_90c165cf45a04c5292db0b7eea9db213"
-       ],
-       "layout": "IPY_MODEL_4ee8a0e03b0c4957a25a128c2d50f5d4",
-       "tabbable": null,
-       "tooltip": null
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
       }
      },
-     "39ac3c9b2c9248e58188bde88e5d542a": {
+     "3a9fe25d23e24cbeb45c0c92a582182a": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -453,7 +494,80 @@
        "width": null
       }
      },
-     "4ee8a0e03b0c4957a25a128c2d50f5d4": {
+     "4e3b240aefe841f8a0248084158f993d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3a9fe25d23e24cbeb45c0c92a582182a",
+       "max": 16.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_b4b562fe298d47f3b4d56e3846f5eacb",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 16.0
+      }
+     },
+     "7118de400bb1442eafa5752cc6c5bbcb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_7329104c37c542b293ccfd0611046139",
+        "IPY_MODEL_4e3b240aefe841f8a0248084158f993d",
+        "IPY_MODEL_80513bd1cec3464e8cadbfa72c52df33"
+       ],
+       "layout": "IPY_MODEL_7426bd7df0a441728b2b306dd4fce118",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "7329104c37c542b293ccfd0611046139": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_a1a9045e48c84d919c015d37188c6284",
+       "placeholder": "​",
+       "style": "IPY_MODEL_1a800a568376411ea0d807398580bb58",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Epoch 64: 100%"
+      }
+     },
+     "7426bd7df0a441728b2b306dd4fce118": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -506,23 +620,30 @@
        "width": "100%"
       }
      },
-     "54721dddcd6445aab2ee8a974bc36b54": {
+     "80513bd1cec3464e8cadbfa72c52df33": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
+      "model_name": "HTMLModel",
       "state": {
+       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
+       "_model_name": "HTMLModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
+       "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f15f94f2c30b49c19984b19e5fa9f386",
+       "placeholder": "​",
+       "style": "IPY_MODEL_e104da1ca6b84b08a2ab6dd117788448",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 16/16 [00:00&lt;00:00, 16.88it/s, v_num=1, loss_/recon_loss_step=414.0, loss_/kld_loss_step=61.10, loss_/consistency_loss_step=0.000, loss/net_step=411.0, loss/dsc_step=63.20, loss_/recon_loss_epoch=1.51e+3, loss_/kld_loss_epoch=79.20, loss_/consistency_loss_epoch=58.20, loss/net_epoch=1.57e+3, loss/dsc_epoch=78.00]"
       }
      },
-     "737974cb592f48dd96dc726efe5b61c6": {
+     "a1a9045e48c84d919c015d37188c6284": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -575,30 +696,23 @@
        "width": null
       }
      },
-     "90c165cf45a04c5292db0b7eea9db213": {
+     "b4b562fe298d47f3b4d56e3846f5eacb": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
+      "model_name": "ProgressStyleModel",
       "state": {
-       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
+       "_model_name": "ProgressStyleModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
+       "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_e288a669839d41f39581cb43cdc38b85",
-       "placeholder": "​",
-       "style": "IPY_MODEL_bbab4f6701f74e20b55d21f3119e0bc2",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 16/16 [00:00&lt;00:00, 17.14it/s, v_num=0, loss_/recon_loss_step=414.0, loss_/kld_loss_step=61.10, loss_/consistency_loss_step=0.000, loss/net_step=411.0, loss/dsc_step=63.20, loss_/recon_loss_epoch=1.51e+3, loss_/kld_loss_epoch=79.20, loss_/consistency_loss_epoch=58.20, loss/net_epoch=1.57e+3, loss/dsc_epoch=78.00]"
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
       }
      },
-     "bbab4f6701f74e20b55d21f3119e0bc2": {
+     "e104da1ca6b84b08a2ab6dd117788448": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -616,74 +730,7 @@
        "text_color": null
       }
      },
-     "c04fd7c0d62f4db1ac61bce7e3fc8987": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_39ac3c9b2c9248e58188bde88e5d542a",
-       "max": 16.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_54721dddcd6445aab2ee8a974bc36b54",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 16.0
-      }
-     },
-     "c2d1dd3030f7426bb2485c04c3d7a500": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "dd59645be4d9462ea87eeb3280ee9463": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_737974cb592f48dd96dc726efe5b61c6",
-       "placeholder": "​",
-       "style": "IPY_MODEL_c2d1dd3030f7426bb2485c04c3d7a500",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Epoch 64: 100%"
-      }
-     },
-     "e288a669839d41f39581cb43cdc38b85": {
+     "f15f94f2c30b49c19984b19e5fa9f386": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",


### PR DESCRIPTION
## Summary
Polish the Colab quickstart based on first-impression testing.

## Four fixes
1. **GPU default** — added `accelerator: "GPU"` + `colab.gpuType: "T4"` to notebook metadata so Colab spins up a T4 by default.
2. **Explicit GPU check** — new cell prints `✓ GPU detected: <name>` or a clear warning with the exact menu path (`Runtime → Change runtime type → T4 GPU`) if running on CPU.
3. **Conditional install (uncommented)** — was `# !pip install scmidas` (commented), now `if importlib.util.find_spec("scmidas") is None: !pip install --quiet scmidas`. Runs install on Colab automatically, no-ops on local Jupyter where scmidas is already importable. `--quiet` reduces noise; a markdown note explains the benign google-colab/pandas resolver warning.
4. **Per-batch dataset breakdown** — replaced the bare `mdata` repr (which just showed shapes) with an explicit table:

   

## Test plan
- [x] Notebook re-executed via `jupyter nbconvert --execute` — all cells run, UMAP renders, breakdown prints correctly.
